### PR TITLE
Fixed minor error in I.12: Declare a pointer that must not be null as not_null

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -1312,7 +1312,7 @@ That is, its value must be `delete`d or transferred to another owner, as is done
 
 **Example**:
 
-	int length(const char* p);		// it is not clear whether strlen(nullptr) is valid
+	int length(const char* p);		// it is not clear whether length(nullptr) is valid
 
 	length(nullptr);				// OK?
 


### PR DESCRIPTION
I found it confusing to mix length and strlen. The note about std::strlen() comes afterward.
